### PR TITLE
Allow wildcard authorizations

### DIFF
--- a/influxdbv2/resource_create_authorization.go
+++ b/influxdbv2/resource_create_authorization.go
@@ -99,7 +99,7 @@ func resourceAuthorizationCreate(d *schema.ResourceData, meta interface{}) error
 
 	result, err := influx.AuthorizationsAPI().CreateAuthorization(context.Background(), &authorizations)
 	if err != nil {
-		return fmt.Errorf("error creating authorization!: %e", err)
+		return fmt.Errorf("error creating authorization: %e", err)
 	}
 	d.SetId(*result.Id)
 	err = d.Set("token", *result.Token)

--- a/influxdbv2/resource_create_authorization.go
+++ b/influxdbv2/resource_create_authorization.go
@@ -174,18 +174,22 @@ func getPermissions(input interface{}) []domain.Permission {
 			resourceSet := perm["resource"].(*schema.Set).List()
 			for _, resource := range resourceSet {
 				res := resource.(map[string]interface{})
-				var id, org_id, name, org &string = nil, nil, nil, nil
+				var id, org_id, name, org *string = nil, nil, nil, nil
 				if res["id"] != nil {
-					id = res["id"].(string)
+					x := res["id"].(string)
+					id = &x
 				}
 				if res["org_id"] != nil {
-					org_id = res["org_id"].(string)
+					x := res["org_id"].(string)
+					org_id = &x
 				}
 				if res["name"] != nil {
-					name = res["name"].(string)
+					x := res["name"].(string)
+					name = &x
 				}
 				if res["org"] != nil {
-					org = res["org"].(string)
+					x := res["org"].(string)
+					org = &x
 				}
 				Resource := domain.Resource{Type: domain.ResourceType(res["type"].(string)), Id: id, OrgID: org_id, Name: name, Org: org}
 				each := domain.Permission{Action: domain.PermissionAction(perm["action"].(string)), Resource: Resource}

--- a/influxdbv2/resource_create_authorization.go
+++ b/influxdbv2/resource_create_authorization.go
@@ -96,7 +96,6 @@ func resourceAuthorizationCreate(d *schema.ResourceData, meta interface{}) error
 		OrgID:       &orgId,
 		Permissions: &permissions,
 	}
-
 	result, err := influx.AuthorizationsAPI().CreateAuthorization(context.Background(), &authorizations)
 	if err != nil {
 		return fmt.Errorf("error creating authorization: %e", err)
@@ -175,19 +174,19 @@ func getPermissions(input interface{}) []domain.Permission {
 			for _, resource := range resourceSet {
 				res := resource.(map[string]interface{})
 				var id, org_id, name, org *string = nil, nil, nil, nil
-				if res["id"] != nil {
+				if res["id"] != nil && res["id"] != "" {
 					x := res["id"].(string)
 					id = &x
 				}
-				if res["org_id"] != nil {
+				if res["org_id"] != nil && res["org_id"] != "" {
 					x := res["org_id"].(string)
 					org_id = &x
 				}
-				if res["name"] != nil {
+				if res["name"] != nil && res["name"] != "" {
 					x := res["name"].(string)
 					name = &x
 				}
-				if res["org"] != nil {
+				if res["org"] != nil && res["org"] != "" {
 					x := res["org"].(string)
 					org = &x
 				}

--- a/influxdbv2/resource_create_authorization.go
+++ b/influxdbv2/resource_create_authorization.go
@@ -99,7 +99,7 @@ func resourceAuthorizationCreate(d *schema.ResourceData, meta interface{}) error
 
 	result, err := influx.AuthorizationsAPI().CreateAuthorization(context.Background(), &authorizations)
 	if err != nil {
-		return fmt.Errorf("error creating authorization: %e", err)
+		return fmt.Errorf("error creating authorization!: %e", err)
 	}
 	d.SetId(*result.Id)
 	err = d.Set("token", *result.Token)

--- a/influxdbv2/resource_create_authorization.go
+++ b/influxdbv2/resource_create_authorization.go
@@ -174,7 +174,7 @@ func getPermissions(input interface{}) []domain.Permission {
 			resourceSet := perm["resource"].(*schema.Set).List()
 			for _, resource := range resourceSet {
 				res := resource.(map[string]interface{})
-				var id, org_id, name, org = "", "", "", ""
+				var id, org_id, name, org &string = nil, nil, nil, nil
 				if res["id"] != nil {
 					id = res["id"].(string)
 				}
@@ -187,7 +187,7 @@ func getPermissions(input interface{}) []domain.Permission {
 				if res["org"] != nil {
 					org = res["org"].(string)
 				}
-				Resource := domain.Resource{Type: domain.ResourceType(res["type"].(string)), Id: &id, OrgID: &org_id, Name: &name, Org: &org}
+				Resource := domain.Resource{Type: domain.ResourceType(res["type"].(string)), Id: id, OrgID: org_id, Name: name, Org: org}
 				each := domain.Permission{Action: domain.PermissionAction(perm["action"].(string)), Resource: Resource}
 				result = append(result, each)
 			}

--- a/influxdbv2/resource_create_authorization.go
+++ b/influxdbv2/resource_create_authorization.go
@@ -45,7 +45,7 @@ func ResourceAuthorization() *schema.Resource {
 								Schema: map[string]*schema.Schema{
 									"id": {
 										Type:     schema.TypeString,
-										Required: true,
+										Optional: true,
 									},
 									"org": {
 										Type:     schema.TypeString,

--- a/influxdbv2/resource_create_authorization_test.go
+++ b/influxdbv2/resource_create_authorization_test.go
@@ -28,7 +28,7 @@ func TestAccAuthorization(t *testing.T) {
 					resource.TestCheckResourceAttrSet("influxdb-v2_authorization.acctest", "token"),
 					resource.TestCheckResourceAttr("influxdb-v2_authorization.acctest", "org_id", os.Getenv("INFLUXDB_V2_ORG_ID")),
 					// permissions is a complex array... we'll just check it has the correct length
-					resource.TestCheckResourceAttr("influxdb-v2_authorization.acctest", "permissions.#", "2"),
+					resource.TestCheckResourceAttr("influxdb-v2_authorization.acctest", "permissions.#", "3"),
 				),
 			},
 			{

--- a/influxdbv2/resource_create_authorization_test.go
+++ b/influxdbv2/resource_create_authorization_test.go
@@ -71,6 +71,13 @@ resource "influxdb-v2_authorization" "acctest" {
             type = "buckets"
         }
     }
+    permissions {
+        action = "write"
+        resource {
+            org_id = "` + os.Getenv("INFLUXDB_V2_ORG_ID") + `"
+            type = "buckets"
+        }
+    }
 }
 `
 }


### PR DESCRIPTION
InfluxDB allows you to leave fields in a permissions block blank (eg id, org_id). This acts as a wildcard permission - for example, if you leave "id" blank and set "org_id=my_org, type='buckets'", then the authorization will allow operations on any bucket in that org.

Previously, that didn't work in this TF provider, so I changed it to use nil rather than blank strings when the field isn't present in the terraform file.

I apologize if my go is not idiomatic, I haven't written go in a while.